### PR TITLE
Fix search output and completion scripts

### DIFF
--- a/spotlighter
+++ b/spotlighter
@@ -46,7 +46,7 @@ find_candidates() {
   if command -v rg >/dev/null 2>&1; then
     rg --files "$DIR" 2>/dev/null |
       grep -E '/(node_modules|venv|\\.venv|\\.direnv)/' |
-      sed -E 's#(.*/(node_modules|venv|\\.venv|\\.direnv)).*#\\1#' |
+      sed -E 's#(.*/(node_modules|venv|\\.venv|\\.direnv)).*#\1#' |
       sort -u
   else
     find "$DIR" \
@@ -101,11 +101,22 @@ generate_completions() {
     cat <<'EOF_INNER'
 # bash completion for spotlighter
 _spotlighter() {
-  local cur cmds opts
+  local cur prev cmds opts
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
   cmds="add show find check completions"
   opts="-d --dir -f --force -v --verbose -h --help"
+  case "$prev" in
+    -d|--dir)
+      COMPREPLY=( $(compgen -d -- "$cur") )
+      return 0
+      ;;
+    completions)
+      COMPREPLY=( $(compgen -W "bash zsh" -- "$cur") )
+      return 0
+      ;;
+  esac
   COMPREPLY=( $(compgen -W "$cmds $opts" -- "$cur") )
   return 0
 }
@@ -116,12 +127,21 @@ EOF_INNER
     cat <<'EOF_INNER'
 #compdef spotlighter
 
-_arguments \
+_arguments -s \
+  '1:command:(add show find check completions)' \
   '-d[Directory to search]:directory:_files -/' \
   '-f[Rebuild exclusions from scratch]' \
   '-v[Print additional information]' \
   '-h[Show help]' \
-  '1:command:(add show find check completions)'
+  '::shell:->shell'
+
+case $state in
+  shell)
+    if [[ $words[2] == completions ]]; then
+      _values 'shell' bash zsh
+    fi
+    ;;
+esac
 EOF_INNER
     ;;
   *)

--- a/spotlighter.rb
+++ b/spotlighter.rb
@@ -1,9 +1,9 @@
 class Spotlighter < Formula
   desc "Manage Spotlight indexing exclusions"
   homepage "https://github.com/mvshmakov/spotlighter"
-  url "https://github.com/mvshmakov/spotlighter/archive/527aae7823f8c208e0cab46284adfb8fb2fa019f.tar.gz"
-  version "0.1.0"
-  sha256 "a8ab341eacd1c319906c0413ce7dc5ed8ebcafff651e150d7c94889eeb822904"
+  url "https://github.com/mvshmakov/spotlighter/archive/cb5be8929d0870386f40953411eb3c62416e4944.tar.gz"
+  version "0.1.1"
+  sha256 "42e7465161ab7e889cf2907fb96533d11c18e057800c9262da642032700e4da2"
   head "https://github.com/mvshmakov/spotlighter.git"
   license "MIT"
 


### PR DESCRIPTION
## Summary
- fix spotlighter's `find` to output correct directories
- enhance bash and zsh completion scripts
- update Homebrew formula with new release sha

## Testing
- `make lint`
- `make format`


------
https://chatgpt.com/codex/tasks/task_e_684218e35d60832b91f634305e07d850